### PR TITLE
Fix trip info panel flashing during page load

### DIFF
--- a/public/assets/components/tripInfo/TripInfo.js
+++ b/public/assets/components/tripInfo/TripInfo.js
@@ -6,7 +6,18 @@ class TripInfo extends HTMLElement {
         this._trip = [];
         this._speed = 0;
         this._defaults = null;
-        this._isHidden = true;
+
+        this.shadowRoot.innerHTML = `
+        <link rel="stylesheet" href="assets/components/tripInfo/TripInfo.css">
+        <div id="trip-info" class="hidden">
+            <div class="legs"></div>
+            <div class="zeros"></div>
+            <div class="totals"></div>
+            <section>
+                <slot name="leg-alternatives"></slot>
+            </section>
+        </div>
+        `;
     }
 
     connectedCallback() {
@@ -34,20 +45,27 @@ class TripInfo extends HTMLElement {
         this._trip = [];
         this._speed = 0;
         this._defaults = null;
-        this._isHidden = true;
-        this.shadowRoot.innerHTML = '';
+        this.shadowRoot.querySelector('#trip-info').classList.add('hidden');
+        this.shadowRoot.querySelector('.legs').innerHTML = '';
+        this.shadowRoot.querySelector('.zeros').innerHTML = '';
+        this.shadowRoot.querySelector('.totals').innerHTML = '';
     }
 
     toggle() {
         const details = this.shadowRoot.querySelector('#trip-info');
         if (!details) return;
-        this._isHidden = !this._isHidden;
         details.classList.toggle('hidden');
     }
 
     render() {
+        const legsEl = this.shadowRoot.querySelector('.legs');
+        const zerosEl = this.shadowRoot.querySelector('.zeros');
+        const totalsEl = this.shadowRoot.querySelector('.totals');
+
         if (!this._trip.length || !this._defaults) {
-            this.shadowRoot.innerHTML = '';
+            legsEl.innerHTML = '';
+            zerosEl.innerHTML = '';
+            totalsEl.innerHTML = '';
             return;
         }
 
@@ -76,36 +94,25 @@ class TripInfo extends HTMLElement {
         );
 
 
-        this.shadowRoot.innerHTML = `
-        <link rel="stylesheet" href="assets/components/tripInfo/TripInfo.css">
-        <div id="trip-info" class="${this._isHidden ? 'hidden' : ''}">
+        legsEl.innerHTML = legViewModels
+            .map(vm => `
+                <p>${vm.title}</p>
+                <p>${vm.mealPlanText}</p>
+            `)
+            .join('');
 
-            <div class="legs">
-            ${legViewModels
-                .map(vm => `
-                    <p>${vm.title}</p>
-                    <p>${vm.mealPlanText}</p>
-                `)
-                .join('')}
-            </div>
+        zerosEl.innerHTML = zeroDayViewModels
+            .map(vm => `
+                <p>${vm.title}</p>
+                <p>${vm.mealPlanText}</p>
+            `)
+            .join('');
 
-            <div class="zeros">
-                ${zeroDayViewModels.map(vm => `
-                    <p>${vm.title}</p>
-                    <p>${vm.mealPlanText}</p>
-                `).join('')}
-            </div>
-            <div class="totals">
-                <p>Total length: ${this._trip.totalDistance.toFixed(2)} km</p>
-                <p>Total meals:</p>
-                Breakfast: ${totals.breakfast}, Lunch: ${totals.lunch}, Dinner: ${totals.dinner}, Snacks: ${totals.snacks}
-            </div>
-            <section>
-                <slot name="leg-alternatives"></slot>
-            </section>
-        </div>
+        totalsEl.innerHTML = `
+            <p>Total length: ${this._trip.totalDistance.toFixed(2)} km</p>
+            <p>Total meals:</p>
+            Breakfast: ${totals.breakfast}, Lunch: ${totals.lunch}, Dinner: ${totals.dinner}, Snacks: ${totals.snacks}
         `;
-
     }
 }
 


### PR DESCRIPTION
## Problem

The trip info panel would briefly render **below the map** and then disappear during page load — a flash-of-unstyled-content (FOUC) visible on every trip load.

## Root cause

`TripInfo` built its entire shadow DOM — including the `<link rel="stylesheet">` — lazily inside `render()`, which fires on the `trip-loaded` event (after GPX routes load and `fitBounds` runs, well into page load). Linked stylesheets in shadow DOM load **asynchronously**, so for a moment the freshly created `#trip-info` div existed with neither `display: none` (hidden) nor `position: absolute` applied — leaving it visible in normal document flow below the map until the CSS arrived.

This didn't affect `PackDetails`/`MealPlan` (which also use `<link>`) because they write their `<link>` + hidden skeleton **once in the constructor**, so their stylesheet loads early and their later `render()` only fills in a content div.

## Fix

Restructure `TripInfo` to match that pattern:

- Build the skeleton and `<link>` **once in the constructor** — the stylesheet now loads at element-upgrade time, long before anything is shown, eliminating the unstyled window.
- `render()` only populates the `.legs` / `.zeros` / `.totals` content divs; it no longer re-issues the `<link>` or resets visibility, so re-renders (e.g. `alternatives-change` re-firing `trip-loaded`) are cheaper and preserve the open/closed state.
- The `hidden` class is now the single source of truth for visibility, replacing the redundant `_isHidden` boolean.

No visual/behavioral change beyond removing the flash.

## Testing

Reload a trip page and watch during load — the info panel stays fully hidden until the info button is clicked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)