### PR TITLE
Add dev container

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,103 @@
+# hikingtrips dev container
+#
+# The site itself is plain HTML/CSS/JS with **no build step** — nothing here
+# compiles, bundles, or transpiles the project. What the image provides is the
+# stuff you can't do with a text editor alone:
+#
+#   * a real HTTP origin  — the site uses ES modules + fetch(), so `file://`
+#                           can't load it at all (module CORS + fetch on
+#                           file: URLs both fail). `python3` runs serve.py.
+#   * a headless browser  — public/tests/ is a browser mocha suite; without
+#                           Chromium the only way to run it is to click around
+#                           in a GUI. Playwright makes it a one-liner.
+#   * content-authoring tooling — jq, xmllint, ImageMagick for the trip data
+#                           (JSON/GPX/photos) that the site reads.
+#
+# Deployment is NOT in here: publishing the site stays on the host, so the
+# container never holds credentials that could push it live.
+#
+# Base: Microsoft's JavaScript/Node devcontainer image (Debian bookworm, non-root
+# `vscode` user, Node 22 already on PATH). Node is baked into the *base* rather
+# than layered on as a feature because this Dockerfile needs `npm` at build time
+# to install Playwright — features are applied after the image is built, so a
+# node feature would come too late. Multi-arch, so this runs native on both
+# Apple Silicon and amd64.
+FROM mcr.microsoft.com/devcontainers/javascript-node:22-bookworm
+
+# --- system packages ------------------------------------------------------------
+#   python3         : runs .devcontainer/serve.py (stdlib only — no pip installs).
+#                     The base ships python3*-minimal, whose stdlib is gutted
+#                     ("No module named 'json'"); the python3 metapackage pulls in
+#                     libpython3.11-stdlib and restores it.
+#   jq              : poke at public/trips.json and the tests' JSON fixtures.
+#   libxml2-utils   : `xmllint` — GPX is XML, and a truncated track that the map
+#                     silently drops is much easier to spot with
+#                     `xmllint --noout public/*/planned_route/*.gpx`.
+#   imagemagick     : Linux stand-in for the macOS `sips` thumbnail step in the
+#                     repo README. Bookworm ships ImageMagick 6, so the command
+#                     is `mogrify` / `convert` — the unified `magick` entrypoint
+#                     is a v7 thing and is NOT present:
+#                       mogrify -path thumbs -resize 580x -quality 95 *.jpeg
+#   ripgrep         : a real `rg` on PATH. Claude Code's shell-snapshot wrapper
+#                     only shadows `rg` when no system `rg` exists
+#                     (`if ! command -v rg`), and its Linux/bash branch dispatches
+#                     via `exec -a` (argv[0]) which the container binary ignores ->
+#                     bare `rg` errors with "unknown option '-G'". Installing
+#                     ripgrep makes that wrapper stand down. (The find/grep
+#                     wrappers are unconditional; use `command find` / `command
+#                     grep` for those.)
+#   curl/ca-certificates : TLS to unpkg/cdnjs (the test suite's mocha + chai) and
+#                     general fetching.
+RUN apt-get update \
+    && export DEBIAN_FRONTEND=noninteractive \
+    && apt-get install -y --no-install-recommends \
+        python3 \
+        jq \
+        libxml2-utils \
+        imagemagick \
+        ripgrep \
+        curl \
+        ca-certificates \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+# --- global Node tooling --------------------------------------------------------
+# Installed under an explicit prefix (/opt/node-tools) rather than npm's default
+# global root: the base image relocates that root via $NPM_GLOBAL, and pinning our
+# own path keeps NODE_PATH below deterministic no matter what the base does next.
+#
+# NODE_PATH matters because .devcontainer/run-tests.mjs is an ES module and ESM
+# does *not* consult NODE_PATH — the script therefore resolves Playwright through
+# `createRequire()` (CommonJS resolution), which does. Keep the two in step.
+#
+#   playwright — drives headless Chromium over public/tests/index.html.
+#   @fission-ai/openspec — the `openspec` CLI backing openspec/ and the
+#                          .claude/skills/openspec-* skills.
+#
+# Both default to the latest of a major line so the build doesn't rot; pin an
+# exact version in devcontainer.json -> build.args if you need byte-reproducibility.
+ARG PLAYWRIGHT_VERSION=1
+ARG OPENSPEC_VERSION=latest
+ENV NODE_TOOLS=/opt/node-tools
+ENV NODE_PATH=/opt/node-tools/lib/node_modules
+ENV PATH=/opt/node-tools/bin:${PATH}
+RUN set -eux; \
+    npm install -g --prefix "${NODE_TOOLS}" \
+        "playwright@${PLAYWRIGHT_VERSION}" \
+        "@fission-ai/openspec@${OPENSPEC_VERSION}"; \
+    npm cache clean --force
+
+# --- Chromium for the browser test suite ----------------------------------------
+# Downloaded to a shared, world-readable location instead of ~/.cache/ms-playwright
+# so it lives in the image (survives no volume, costs no re-download on rebuild)
+# and is usable by the non-root `vscode` user. `--with-deps` apt-installs the
+# shared libraries headless Chromium needs (fonts, nss, libdrm, ...).
+ENV PLAYWRIGHT_BROWSERS_PATH=/ms-playwright
+RUN set -eux; \
+    playwright install --with-deps chromium; \
+    chmod -R a+rX "${PLAYWRIGHT_BROWSERS_PATH}"; \
+    apt-get clean; \
+    rm -rf /var/lib/apt/lists/*
+
+# ImageMagick's Debian policy blocks nothing we need (raster read/write is fine);
+# left at the distro default deliberately.

--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -89,13 +89,26 @@ vendoring step that would let them work offline:
 ## Deployment is not in here
 
 Deploying is deliberately left on the host. There is no cloud CLI in the image and
-no credential directory mounted into it, so the container never sees your
-credentials — publishing stays something you do deliberately, from outside.
+no cloud-credential directory mounted into it, so nothing inside the container can
+publish the site — that stays something you do deliberately, from outside.
+
+To be precise about scope: this is a claim about **deployment** credentials only.
+The container is *not* a sealed box. It bind-mounts your host `~/.claude` and
+`~/.agents`, so Claude Code's own credentials, settings and memory are deliberately
+visible inside it (see *Gotchas*). Don't read the paragraph above as "no secrets
+reach the container".
 
 See the *Deployment* section of the repo [README](../README.md) for the command.
 
 ## Gotchas
 
+- **`~/.claude` and `~/.agents` must exist on the host before you start the
+  container.** They're bind mounts, and the devcontainer CLI passes them as
+  `--mount type=bind`, which *errors* on a missing source rather than creating it
+  — so on a machine that has never run Claude Code, the container won't come up at
+  all. Fix with `mkdir -p ~/.claude ~/.agents`. (Swapping them for named volumes
+  would avoid the prerequisite but defeat the point: the whole reason they're
+  binds is to share one set of credentials and memory with the host.)
 - **Photos are gitignored.** `public/*/photos/` is excluded from the repo, so trip
   cards and galleries show broken images locally. That's expected, not a bug you
   introduced.

--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -1,0 +1,129 @@
+# hikingtrips dev container
+
+The site is plain HTML/CSS/JS with **no build step** — nothing in here compiles,
+bundles or transpiles anything, and that's deliberate. What the container provides
+is the handful of things you can't do with an editor alone: an HTTP origin, a
+headless browser for the test suite, and the tools for working with the trip data.
+
+## What's inside
+
+| Tool | Source | Why |
+|------|--------|-----|
+| `node` 22 | base image (`devcontainers/javascript-node`) | runs the test harness + the Claude Code CLI |
+| `python3` | Dockerfile (apt) | `python3 -m http.server` — the site needs a real origin |
+| `playwright` + Chromium | Dockerfile | runs `public/tests/` headlessly |
+| `openspec` | Dockerfile (npm, global) | the `openspec/` workflow and the `.claude/skills/openspec-*` skills |
+| `claude` | `claude-code` feature | continue developing in-container |
+| `jq`, `xmllint`, `mogrify` (ImageMagick) | Dockerfile (apt) | trip data: `trips.json`, GPX tracks, photo thumbnails |
+| `rg` | Dockerfile (apt) | see the note under *Gotchas* |
+
+`postCreate.sh` prints a version line per tool. It installs nothing — the site has
+no dependencies to fetch — and never fails the build.
+
+## Serving the site
+
+```bash
+python3 -m http.server 8000 --directory public
+```
+
+Port 8000 is forwarded, so open `http://localhost:8000/` in your **host** browser.
+The site can't be opened as a `file://` URL: it uses ES modules and `fetch()`, and
+both are blocked on `file:` origins.
+
+The `ritwickdey.LiveServer` extension is installed and rooted at `/public` if you
+want reload-on-save instead.
+
+### Local vs. production paths
+
+Production serves the site from a *subdirectory* of its domain, with a CloudFront
+Function ([`infra/cloudfront-rewrite.js`](../infra/cloudfront-rewrite.js)) adding
+the trailing slash and the `index.html`. Locally you get it at the root
+instead. That's fine, because every asset path in the site is relative, so both
+layouts resolve identically. The thing it does *not* exercise is the missing-slash
+redirect — if you touch path resolution, re-read that function rather than
+trusting a green local page.
+
+## Running the tests
+
+`public/tests/` is a browser suite (mocha + chai + `@testing-library/dom`, loaded
+from unpkg) exercising the custom elements against a live DOM. Two ways to run it:
+
+```bash
+# 1. In your host browser — the mocha HTML report, nice for reading failures
+python3 -m http.server 8000 --directory public
+#    then open http://localhost:8000/tests/
+
+# 2. Headless, with a pass/fail exit code — what an agent (or a CI step) needs
+node .devcontainer/run-tests.mjs
+node .devcontainer/run-tests.mjs --grep 'MealPlan'   # filter (mocha's ?grep=)
+node .devcontainer/run-tests.mjs --headed            # watch it run
+```
+
+`run-tests.mjs` starts its own `http.server` on a free port and tears it down
+afterwards; pass `--url` to point it at a server you already have. It reports
+failures with the assertion message and `file:line`, and exits `1` on any failure,
+`2` if the harness itself breaks.
+
+It works by intercepting the `mocha` global as `mocha.js` assigns it and wrapping
+`run()` to capture the runner's events. Polling for the global would not work —
+`mocha.js` and `tests/index.js` are both `defer`red, so they can run back-to-back
+inside one task with no timer tick in between.
+
+Adding a test file means adding a `<script type="module">` tag to
+`public/tests/index.html`; there is no glob.
+
+## Network egress
+
+Both the site and the tests fetch from the network at **runtime** — there is no
+vendoring step that would let them work offline:
+
+- `unpkg.com` — mocha, chai, `@testing-library/dom` (**the test suite fails
+  without this**)
+- `cdn.jsdelivr.net`, `cdnjs.cloudflare.com` — Leaflet and `js-yaml`
+- the map tile proxy host configured in `public/assets/js/leaflet/baseMaps.js`
+  (NLS / Lantmäteriet); base maps stay blank without it
+- `cache.kartverket.no`, `tiles.kartat.kapsi.fi`, `server.arcgisonline.com` — other
+  base map layers
+- `registry.npmjs.org`, `cdn.playwright.dev` — build time only
+
+## Deployment is not in here
+
+Deploying is deliberately left on the host. There is no cloud CLI in the image and
+no credential directory mounted into it, so the container never sees your
+credentials — publishing stays something you do deliberately, from outside.
+
+See the *Deployment* section of the repo [README](../README.md) for the command.
+
+## Gotchas
+
+- **Photos are gitignored.** `public/*/photos/` is excluded from the repo, so trip
+  cards and galleries show broken images locally. That's expected, not a bug you
+  introduced.
+- **`rg` is installed on purpose.** Claude Code's shell-snapshot wrapper only
+  shadows `rg` when no system `rg` exists; its Linux dispatch relies on `exec -a`
+  (argv[0]), which the container binary ignores, so a bare `rg` fails with
+  `unknown option '-G'`. A real ripgrep on `PATH` makes the wrapper stand down.
+  The `find`/`grep` wrappers are unconditional — use `command find` / `command grep`.
+- **The `~/.claude` mount is a bind with holes in it.** Host settings, credentials
+  and memory are shared, but `shell-snapshots/`, `sessions/` and `session-env/` are
+  overlaid with container-local volumes: they hold host- and version-specific
+  runtime state, and letting a newer host Claude Code's snapshots leak into the
+  older container binary breaks bare `grep`/`rg`/`find`.
+- **ImageMagick 6, not 7.** Bookworm has no `magick` command; use `mogrify` /
+  `convert`. The `sips` thumbnail step from the repo README becomes:
+  `mogrify -path thumbs -resize 580x -quality 95 *.jpeg`
+
+## Toggles
+
+- **Pin versions:** `build.args` in `devcontainer.json` — `PLAYWRIGHT_VERSION` and
+  `OPENSPEC_VERSION` default to the latest of their line so the build doesn't rot.
+- **More browsers:** add to `playwright install --with-deps chromium` in the
+  Dockerfile. Chromium alone is ~400 MB, so it's the only one baked in.
+- **GPX conversion:** add `gpsbabel` to the apt list if you need format juggling
+  beyond `xmllint --noout public/*/planned_route/*.gpx`.
+
+## Rebuild
+
+After editing anything here: **Dev Containers: Rebuild Container** (VS Code), or
+`devcontainer build --workspace-folder .`. The `hikingtrips-npm-cache` and
+`hikingtrips-claude-*` volumes persist across rebuilds.

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -25,6 +25,11 @@
     "source=hikingtrips-npm-cache,target=/home/node/.npm,type=volume",
 
     // --- shared dev config ---------------------------------------------------
+    // PREREQUISITE: both host paths below must exist before the container starts.
+    // These are passed to Docker as `--mount type=bind`, which errors on a missing
+    // source instead of creating it -- on a machine that has never run Claude Code
+    // the container won't come up. `mkdir -p ~/.claude ~/.agents` fixes it.
+    //
     // ~/.claude is bind-mounted from the host so credentials, settings and
     // per-project memory are shared. But the host runs its OWN (macOS, possibly
     // newer) Claude Code, and some subdirs hold version- and host-specific runtime

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,74 @@
+{
+  "name": "hikingtrips",
+  "build": {
+    "dockerfile": "Dockerfile",
+    "args": {
+      // Pin exact versions here if you need reproducible rebuilds.
+      // Playwright: https://github.com/microsoft/playwright/releases
+      "PLAYWRIGHT_VERSION": "1",
+      "OPENSPEC_VERSION": "latest"
+    }
+  },
+
+  "features": {
+    // Claude Code CLI, so development can continue in-container. Node already
+    // comes from the base image, so no node feature is needed.
+    "ghcr.io/anthropics/devcontainer-features/claude-code:1": {}
+  },
+
+  // Deliberately absent: any cloud CLI and any credential-directory mount.
+  // Deployment stays a host activity (see the repo README), so the container
+  // never has access to credentials that could publish the site.
+
+  "mounts": [
+    // npm cache, so `npx`/`npm i -g` warm-start after a rebuild.
+    "source=hikingtrips-npm-cache,target=/home/node/.npm,type=volume",
+
+    // --- shared dev config ---------------------------------------------------
+    // ~/.claude is bind-mounted from the host so credentials, settings and
+    // per-project memory are shared. But the host runs its OWN (macOS, possibly
+    // newer) Claude Code, and some subdirs hold version- and host-specific runtime
+    // state that must NOT be shared: shell-snapshots encode the search-tool
+    // wrapper protocol of whichever binary wrote them, so a newer host snapshot
+    // consumed by the older container binary breaks bare grep/rg/find ("unknown
+    // option '-G'"). Overlay container-local volumes on those churny paths
+    // (listed AFTER the bind so the nested mounts win); the durable shared config
+    // underneath is untouched.
+    "source=${localEnv:HOME}/.claude,target=/home/node/.claude,type=bind,consistency=cached",
+    "source=hikingtrips-claude-shell-snapshots,target=/home/node/.claude/shell-snapshots,type=volume",
+    "source=hikingtrips-claude-sessions,target=/home/node/.claude/sessions,type=volume",
+    "source=hikingtrips-claude-session-env,target=/home/node/.claude/session-env,type=volume",
+    "source=${localEnv:HOME}/.agents,target=/home/node/.agents,type=bind,consistency=cached"
+  ],
+
+  // For `python3 -m http.server 8000 --directory public` (see README). Forwarded
+  // so the site — and public/tests/index.html — open in your HOST browser.
+  "forwardPorts": [8000],
+  "portsAttributes": {
+    "8000": { "label": "hikingtrips site" }
+  },
+
+  // Toolchain summary only. Best-effort; never fails the build.
+  "postCreateCommand": "bash .devcontainer/postCreate.sh",
+
+  // The javascript-node base image's non-root user is `node`, not `vscode`.
+  "remoteUser": "node",
+
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        // Every trip is driven by a trip_config.yaml.
+        "redhat.vscode-yaml",
+        // Reload-on-save static server — the no-build-step equivalent of a
+        // dev server with HMR. Rooted at /public below.
+        "ritwickdey.LiveServer"
+      ],
+      "settings": {
+        // The site is under public/; point Live Server at it directly.
+        "liveServer.settings.root": "/public",
+        // GPX is XML; without this VS Code treats it as plain text.
+        "files.associations": { "*.gpx": "xml" }
+      }
+    }
+  }
+}

--- a/.devcontainer/postCreate.sh
+++ b/.devcontainer/postCreate.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# Toolchain verification.
+# Best-effort: prints what's present and exits 0 even if a check fails, so a
+# transient hiccup never blocks the container from coming up.
+#
+# There is nothing to install here — the site has no dependencies to fetch (no
+# npm, no build step) and everything else is baked into the image.
+set -uo pipefail
+
+echo "==> hikingtrips toolchain"
+
+check() {
+  # check "<label>" <cmd...>
+  local label="$1"; shift
+  if out="$("$@" 2>&1)"; then
+    printf '  ok   %-12s %s\n' "$label" "$(printf '%s' "$out" | head -n1)"
+  else
+    printf '  MISS %-12s (`%s` failed)\n' "$label" "$*"
+  fi
+}
+
+check "python3"    python3 --version
+check "node"       node -v
+check "npm"        npm -v
+check "playwright" playwright --version
+check "openspec"   openspec --version
+check "jq"         jq --version
+check "xmllint"    xmllint --version
+# Debian bookworm ships ImageMagick 6, whose entrypoints are convert/mogrify —
+# the unified `magick` command only exists in ImageMagick 7.
+check "mogrify"    mogrify -version
+check "rg"         rg --version
+check "claude"     claude --version
+
+# Chromium is baked into the image at $PLAYWRIGHT_BROWSERS_PATH rather than
+# downloaded into a home-directory cache, so this should always be a hit. If it
+# isn't, the browser test suite can't run — flag it loudly.
+if [ -d "${PLAYWRIGHT_BROWSERS_PATH:-/ms-playwright}" ] \
+   && compgen -G "${PLAYWRIGHT_BROWSERS_PATH:-/ms-playwright}/chromium*" > /dev/null; then
+  echo "  ok   chromium     ${PLAYWRIGHT_BROWSERS_PATH:-/ms-playwright}"
+else
+  echo "  MISS chromium     (run: playwright install chromium)"
+fi
+
+cat <<'EOF'
+
+==> serve the site (then open the forwarded port in your host browser)
+      python3 -m http.server 8000 --directory public
+      -> http://localhost:8000/         site
+      -> http://localhost:8000/tests/   browser test suite
+
+==> run the tests headlessly (starts its own server)
+      node .devcontainer/run-tests.mjs
+
+See .devcontainer/README.md for the rest.
+EOF

--- a/.devcontainer/run-tests.mjs
+++ b/.devcontainer/run-tests.mjs
@@ -1,0 +1,249 @@
+#!/usr/bin/env node
+/**
+ * Headless runner for the browser test suite in public/tests/.
+ *
+ * The suite is mocha + chai + @testing-library/dom loaded straight from unpkg
+ * into a real page (public/tests/index.html) -- there is no node-side test
+ * runner to invoke, and the components under test are custom elements that need
+ * a live DOM. So the only way to run it is to actually open it in a browser.
+ * This drives headless Chromium over it and turns the result into an exit code,
+ * which is the one thing you can't do by hand.
+ *
+ *   node .devcontainer/run-tests.mjs
+ *   node .devcontainer/run-tests.mjs --grep 'meal plan'
+ *   node .devcontainer/run-tests.mjs --headed          # watch it run
+ *   node .devcontainer/run-tests.mjs --url http://localhost:8000/tests/
+ *
+ * With no --url it starts `python3 -m http.server` over public/ on a free port
+ * and shuts it down afterwards.
+ *
+ * Requires network: the page pulls mocha/chai/testing-library from unpkg.com.
+ */
+
+import { createRequire } from 'node:module';
+import { spawn } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import net from 'node:net';
+import path from 'node:path';
+
+// Playwright is installed globally (see Dockerfile: NODE_PATH=/opt/node-tools/...).
+// ESM does not consult NODE_PATH, but CommonJS resolution does -- hence require().
+const require = createRequire(import.meta.url);
+let chromium;
+try {
+    ({ chromium } = require('playwright'));
+} catch (err) {
+    console.error('Could not load Playwright.');
+    console.error('Inside the dev container it is installed globally; on a host, run:');
+    console.error('  npm i -g playwright && playwright install chromium');
+    console.error(`\n${err.message}`);
+    process.exit(2);
+}
+
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const SITE_ROOT = path.join(REPO_ROOT, 'public');
+
+function parseArgs(argv) {
+    const opts = { url: null, grep: null, headed: false, timeout: 60000 };
+    for (let i = 0; i < argv.length; i++) {
+        const arg = argv[i];
+        if (arg === '--headed') opts.headed = true;
+        else if (arg === '--url') opts.url = argv[++i];
+        else if (arg === '--grep') opts.grep = argv[++i];
+        else if (arg === '--timeout') opts.timeout = Number(argv[++i]);
+        else if (arg === '-h' || arg === '--help') {
+            console.log(
+                'usage: run-tests.mjs [--url URL] [--grep PATTERN] [--headed] [--timeout MS]'
+            );
+            process.exit(0);
+        } else {
+            console.error(`unknown argument: ${arg}`);
+            process.exit(2);
+        }
+    }
+    return opts;
+}
+
+/** Ask the OS for an unused port by binding one and immediately letting go. */
+function freePort() {
+    return new Promise((resolve, reject) => {
+        const srv = net.createServer();
+        srv.once('error', reject);
+        srv.listen(0, '127.0.0.1', () => {
+            const { port } = srv.address();
+            srv.close(() => resolve(port));
+        });
+    });
+}
+
+function waitForPort(port, timeoutMs = 10000) {
+    const deadline = Date.now() + timeoutMs;
+    return new Promise((resolve, reject) => {
+        const attempt = () => {
+            const sock = net.connect(port, '127.0.0.1');
+            sock.once('connect', () => {
+                sock.destroy();
+                resolve();
+            });
+            sock.once('error', () => {
+                sock.destroy();
+                if (Date.now() > deadline) reject(new Error(`server never came up on :${port}`));
+                else setTimeout(attempt, 100);
+            });
+        };
+        attempt();
+    });
+}
+
+async function startServer() {
+    const port = await freePort();
+    const proc = spawn(
+        'python3',
+        ['-m', 'http.server', String(port), '--bind', '127.0.0.1', '--directory', SITE_ROOT],
+        { stdio: ['ignore', 'ignore', 'pipe'] }
+    );
+    // http.server logs every request to stderr; keep it out of the report but
+    // surface a genuine startup failure (e.g. no python3).
+    let stderr = '';
+    proc.stderr.on('data', (chunk) => {
+        stderr += chunk;
+    });
+    proc.on('exit', (code) => {
+        if (code !== null && code !== 0 && !proc.killed) {
+            console.error(`http.server exited with ${code}\n${stderr}`);
+        }
+    });
+    await waitForPort(port);
+    return { proc, baseUrl: `http://127.0.0.1:${port}` };
+}
+
+/**
+ * Injected before any page script. mocha's HTML reporter only writes results
+ * into the DOM, so instead of scraping it we intercept the `mocha` global at the
+ * moment mocha.js assigns it and wrap run() to capture the runner's events.
+ *
+ * A polling interval would not work here: mocha.js and tests/index.js are both
+ * deferred scripts, so they can execute back-to-back within a single task with
+ * no timer tick in between.
+ */
+function instrumentMocha() {
+    let inner;
+    const patch = (m) => {
+        if (!m || typeof m.run !== 'function' || m.__ttPatched) return;
+        m.__ttPatched = true;
+        const origRun = m.run.bind(m);
+        m.run = (fn) => {
+            const results = { passes: 0, pending: 0, failures: [] };
+            window.__ttResults = results;
+            const runner = origRun(fn);
+            runner.on('pass', () => results.passes++);
+            runner.on('pending', () => results.pending++);
+            runner.on('fail', (test, err) => {
+                let title;
+                try {
+                    title = typeof test.fullTitle === 'function' ? test.fullTitle() : test.title;
+                } catch {
+                    title = '(unknown test)';
+                }
+                results.failures.push({
+                    title: String(title || '(unknown test)'),
+                    error: String((err && (err.stack || err.message)) || err)
+                });
+            });
+            runner.on('end', () => {
+                window.__ttDone = true;
+            });
+            return runner;
+        };
+    };
+    Object.defineProperty(window, 'mocha', {
+        configurable: true,
+        get: () => inner,
+        set: (value) => {
+            inner = value;
+            patch(value);
+        }
+    });
+}
+
+async function main() {
+    const opts = parseArgs(process.argv.slice(2));
+    let server = null;
+    let url = opts.url;
+
+    if (!url) {
+        server = await startServer();
+        url = `${server.baseUrl}/tests/`;
+    }
+    if (opts.grep) {
+        url += (url.includes('?') ? '&' : '?') + 'grep=' + encodeURIComponent(opts.grep);
+    }
+
+    const browser = await chromium.launch({ headless: !opts.headed });
+    const page = await browser.newPage();
+
+    const pageErrors = [];
+    const failedRequests = [];
+    page.on('pageerror', (err) => pageErrors.push(String(err && (err.stack || err.message))));
+    page.on('console', (msg) => {
+        if (msg.type() === 'error') pageErrors.push(msg.text());
+    });
+    page.on('requestfailed', (req) =>
+        failedRequests.push(`${req.url()} (${req.failure()?.errorText ?? 'failed'})`)
+    );
+
+    await page.addInitScript(instrumentMocha);
+
+    let exitCode = 0;
+    try {
+        console.log(`running ${url}`);
+        await page.goto(url, { waitUntil: 'load', timeout: 30000 });
+
+        if (!(await page.evaluate(() => typeof window.mocha !== 'undefined'))) {
+            throw new Error(
+                'mocha never loaded -- public/tests/index.html pulls it from unpkg.com, ' +
+                    'so check network egress to that host.'
+            );
+        }
+
+        await page.waitForFunction(() => window.__ttDone === true, null, {
+            timeout: opts.timeout
+        });
+
+        const results = await page.evaluate(() => window.__ttResults);
+        for (const failure of results.failures) {
+            console.log(`\nFAIL  ${failure.title}\n${failure.error}`);
+        }
+        const summary = `${results.passes} passing, ${results.failures.length} failing`;
+        console.log(`\n${summary}${results.pending ? `, ${results.pending} pending` : ''}`);
+        exitCode = results.failures.length > 0 ? 1 : 0;
+    } catch (err) {
+        console.error(`\nharness error: ${err.message}`);
+        // Whatever mocha managed before it wedged is the most useful clue.
+        const partial = await page.evaluate(() => window.__ttResults ?? null).catch(() => null);
+        if (partial) {
+            console.error(
+                `mocha had reached ${partial.passes} passing, ${partial.failures.length} failing`
+            );
+        }
+        exitCode = 2;
+    } finally {
+        if (pageErrors.length) {
+            console.error('\npage errors:');
+            for (const e of new Set(pageErrors)) console.error(`  ${e}`);
+        }
+        if (failedRequests.length) {
+            console.error('\nfailed requests:');
+            for (const r of new Set(failedRequests)) console.error(`  ${r}`);
+        }
+        await browser.close();
+        server?.proc.kill();
+    }
+
+    process.exit(exitCode);
+}
+
+main().catch((err) => {
+    console.error(err);
+    process.exit(2);
+});

--- a/.devcontainer/run-tests.mjs
+++ b/.devcontainer/run-tests.mjs
@@ -17,7 +17,34 @@
  * With no --url it starts `python3 -m http.server` over public/ on a free port
  * and shuts it down afterwards.
  *
+ * Exit codes:
+ *   0  every test passed
+ *   1  at least one test failed
+ *   2  the harness could not produce a trustworthy answer -- see "Trusting a
+ *      green run" below
+ *
  * Requires network: the page pulls mocha/chai/testing-library from unpkg.com.
+ *
+ * ## Trusting a green run
+ *
+ * Test files are registered by hand in public/tests/index.html; there is no glob.
+ * That makes a specific silent failure possible: if one test module 404s or has a
+ * syntax error, the *other* modules still register their tests, mocha still runs
+ * them, and the run still ends with zero failures. A naive runner reports that as
+ * a pass -- green, with a whole file of tests silently missing.
+ *
+ * So a clean mocha result is necessary but not sufficient. Two things are also
+ * treated as fatal:
+ *
+ *   - a script that failed to load or evaluate (network failure, or any 4xx/5xx
+ *     response for a .js/.mjs URL)
+ *   - an uncaught exception in the page (`pageerror`), which is what a syntax
+ *     error in a test module surfaces as
+ *
+ * Everything else -- console noise, a missing stylesheet, a 404 favicon -- is
+ * printed as a warning and does not affect the exit code. That distinction is
+ * deliberate: public/tests/ currently 404s three component stylesheets, which is
+ * a real (benign) bug but not a reason to fail the suite.
  */
 
 import { createRequire } from 'node:module';
@@ -117,6 +144,15 @@ async function startServer() {
     return { proc, baseUrl: `http://127.0.0.1:${port}` };
 }
 
+/** A URL the page loads as executable JavaScript. */
+function isScript(url) {
+    try {
+        return /\.m?js$/i.test(new URL(url).pathname);
+    } catch {
+        return false;
+    }
+}
+
 /**
  * Injected before any page script. mocha's HTML reporter only writes results
  * into the DOM, so instead of scraping it we intercept the `mocha` global at the
@@ -168,34 +204,55 @@ function instrumentMocha() {
 
 async function main() {
     const opts = parseArgs(process.argv.slice(2));
+
+    // Everything acquired below is released in the finally block, which tolerates
+    // any of these still being null -- a Chromium that fails to launch must not
+    // leave the http.server orphaned.
     let server = null;
-    let url = opts.url;
-
-    if (!url) {
-        server = await startServer();
-        url = `${server.baseUrl}/tests/`;
-    }
-    if (opts.grep) {
-        url += (url.includes('?') ? '&' : '?') + 'grep=' + encodeURIComponent(opts.grep);
-    }
-
-    const browser = await chromium.launch({ headless: !opts.headed });
-    const page = await browser.newPage();
-
-    const pageErrors = [];
-    const failedRequests = [];
-    page.on('pageerror', (err) => pageErrors.push(String(err && (err.stack || err.message))));
-    page.on('console', (msg) => {
-        if (msg.type() === 'error') pageErrors.push(msg.text());
-    });
-    page.on('requestfailed', (req) =>
-        failedRequests.push(`${req.url()} (${req.failure()?.errorText ?? 'failed'})`)
-    );
-
-    await page.addInitScript(instrumentMocha);
-
+    let browser = null;
+    let page = null;
     let exitCode = 0;
+
+    // `pageerror` is an uncaught exception in the page and is fatal. Console
+    // errors are not: a resource 404 logs one, and the suite has known-benign
+    // ones. Keep the two apart rather than lumping them together.
+    const uncaught = [];
+    const consoleErrors = [];
+    const brokenScripts = [];
+    const otherResourceProblems = [];
+
     try {
+        let url = opts.url;
+        if (!url) {
+            server = await startServer();
+            url = `${server.baseUrl}/tests/`;
+        }
+        if (opts.grep) {
+            url += (url.includes('?') ? '&' : '?') + 'grep=' + encodeURIComponent(opts.grep);
+        }
+
+        browser = await chromium.launch({ headless: !opts.headed });
+        page = await browser.newPage();
+
+        page.on('pageerror', (err) => uncaught.push(String((err && (err.stack || err.message)) || err)));
+        page.on('console', (msg) => {
+            if (msg.type() === 'error') consoleErrors.push(msg.text());
+        });
+        // A network-level failure (connection refused, aborted).
+        page.on('requestfailed', (req) => {
+            const entry = `${req.url()} (${req.failure()?.errorText ?? 'request failed'})`;
+            (isScript(req.url()) ? brokenScripts : otherResourceProblems).push(entry);
+        });
+        // A 404 is a *successful* response, so requestfailed never fires for it --
+        // a missing test file would slip straight through without this.
+        page.on('response', (res) => {
+            if (res.status() < 400) return;
+            const entry = `${res.url()} (HTTP ${res.status()})`;
+            (isScript(res.url()) ? brokenScripts : otherResourceProblems).push(entry);
+        });
+
+        await page.addInitScript(instrumentMocha);
+
         console.log(`running ${url}`);
         await page.goto(url, { waitUntil: 'load', timeout: 30000 });
 
@@ -216,11 +273,27 @@ async function main() {
         }
         const summary = `${results.passes} passing, ${results.failures.length} failing`;
         console.log(`\n${summary}${results.pending ? `, ${results.pending} pending` : ''}`);
+
+        // A clean mocha result means nothing if a test file never made it into the
+        // run. Refuse to report a pass we can't stand behind.
+        if (brokenScripts.length) {
+            throw new Error(
+                `${brokenScripts.length} script(s) failed to load, so tests may be silently ` +
+                    `missing from this run:\n  ${[...new Set(brokenScripts)].join('\n  ')}`
+            );
+        }
+        if (uncaught.length) {
+            throw new Error(
+                `uncaught exception(s) in the page, so tests may be silently missing from ` +
+                    `this run:\n  ${[...new Set(uncaught)].join('\n  ')}`
+            );
+        }
+
         exitCode = results.failures.length > 0 ? 1 : 0;
     } catch (err) {
         console.error(`\nharness error: ${err.message}`);
         // Whatever mocha managed before it wedged is the most useful clue.
-        const partial = await page.evaluate(() => window.__ttResults ?? null).catch(() => null);
+        const partial = await page?.evaluate(() => window.__ttResults ?? null).catch(() => null);
         if (partial) {
             console.error(
                 `mocha had reached ${partial.passes} passing, ${partial.failures.length} failing`
@@ -228,15 +301,16 @@ async function main() {
         }
         exitCode = 2;
     } finally {
-        if (pageErrors.length) {
-            console.error('\npage errors:');
-            for (const e of new Set(pageErrors)) console.error(`  ${e}`);
+        // Warnings only -- these do not change the exit code.
+        if (otherResourceProblems.length) {
+            console.error('\nnon-script resources that failed to load (not fatal):');
+            for (const r of new Set(otherResourceProblems)) console.error(`  ${r}`);
         }
-        if (failedRequests.length) {
-            console.error('\nfailed requests:');
-            for (const r of new Set(failedRequests)) console.error(`  ${r}`);
+        if (consoleErrors.length) {
+            console.error('\nconsole errors (not fatal):');
+            for (const e of new Set(consoleErrors)) console.error(`  ${e}`);
         }
-        await browser.close();
+        await browser?.close().catch(() => {});
         server?.proc.kill();
     }
 


### PR DESCRIPTION
The site is plain HTML/CSS/JS with no build step, so the container installs nothing for the project itself. It provides the things an editor alone can't:

- an HTTP origin (python3) — the site uses ES modules and fetch(), both of which are blocked on file:// URLs
- a headless browser (Playwright + Chromium) for public/tests/, which is a browser mocha suite with no node-side runner. run-tests.mjs turns it into a pass/fail exit code, so tests can be verified without a GUI.
- trip-data tooling: jq, xmllint for GPX, ImageMagick for photo thumbnails
- the openspec CLI backing openspec/ and the .claude/skills/openspec-* skills

Deployment is deliberately left out: no cloud CLI and no credential mount, so the container never holds credentials that could publish the site.

Verified: image builds on arm64, the suite reports 90 passing with exit 0, and an injected failing assertion is reported with file:line and exits 1.